### PR TITLE
Add in-app update center and themed updater

### DIFF
--- a/RazorReaper/App.xaml.cs
+++ b/RazorReaper/App.xaml.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Threading.Tasks;
-using Microsoft.Maui.ApplicationModel;
 using RazorReaper.Services;
 
 namespace RazorReaper
@@ -18,12 +16,6 @@ namespace RazorReaper
             var window = new Window(new MainPage())
             {
                 Title = $"Razor Reaper : Version {version}"
-            };
-
-            window.Created += async (_, __) =>
-            {
-                await Task.Delay(TimeSpan.FromSeconds(1.5));
-                MainThread.BeginInvokeOnMainThread(UpdateService.CheckForUpdates);
             };
 
             return window;

--- a/RazorReaper/Components/Pages/Home.razor
+++ b/RazorReaper/Components/Pages/Home.razor
@@ -15,6 +15,7 @@
 @inject IOptions<AppConfiguration> Configuration
 @inject IJSRuntime JSRuntime
 @inject INotificationService NotificationService
+@inject HttpClient HttpClient
 @implements IAsyncDisposable
 
 
@@ -24,6 +25,61 @@
         </header>
 
         <div class="dashboard-widgets">
+            <div class="content-card widget-card update-widget">
+                <div class="widget-header">
+                    <svg fill="currentColor" viewBox="0 0 20 20" class="widget-icon">
+                        <path d="M10 2a1 1 0 01.894.553l2 4a1 1 0 01-.13 1.047l-1.638 2.185A3.992 3.992 0 0112 12a4 4 0 11-6.528-3.047L3.894 7.6a1 1 0 01-.13-1.047l2-4A1 1 0 016 2h4zm-2 9a2 2 0 102.001-2.001A2 2 0 008 11zm-5 6a1 1 0 01.293-.707l3.84-3.84a5.962 5.962 0 002.162 1.373l-4.29 4.29A1 1 0 013 17zm14 0a1 1 0 01-1.005.995L12 17a1 1 0 01-.707-1.707l2.97-2.97A5.971 5.971 0 0014 11a5.958 5.958 0 00-.55-2.5l2.837-2.837A1 1 0 0117 6v11z" />
+                    </svg>
+                    <div class="update-header-text">
+                        <h3>Update Center</h3>
+                        <p>Stay in sync with Razor Reaper releases</p>
+                    </div>
+                    <span class="version-pill">v@updateStatus.DisplayCurrentVersion</span>
+                </div>
+
+                <div class="update-status-row">
+                    <div class="status-chip @GetUpdateStatusClass()">
+                        <span class="status-dot"></span>
+                        @GetUpdateStatusMessage()
+                    </div>
+                    @if (updateStatus.CheckedAt.HasValue)
+                    {
+                        <span class="checked-at">Checked @updateStatus.CheckedAt.Value.ToLocalTime().ToString("t")</span>
+                    }
+                </div>
+
+                <div class="version-grid">
+                    <div class="version-card">
+                        <p class="label">Current</p>
+                        <p class="value">@updateStatus.DisplayCurrentVersion</p>
+                    </div>
+                    <div class="version-card latest">
+                        <p class="label">Latest</p>
+                        <p class="value">@updateStatus.DisplayLatestVersion</p>
+                    </div>
+                </div>
+
+                <div class="update-actions">
+                    <button class="btn" @onclick="() => CheckForUpdatesAsync()" disabled="@(isCheckingUpdates)">
+                        @if (isCheckingUpdates)
+                        {
+                            <span class="loader"></span>
+                            <span>Checking...</span>
+                        }
+                        else
+                        {
+                            <span>Check for updates</span>
+                        }
+                    </button>
+                    <button class="btn btn-primary" @onclick="DownloadUpdateAsync" disabled="@(isCheckingUpdates || !CanDownloadUpdate)">
+                        Download update
+                    </button>
+                    <button class="btn btn-tertiary" @onclick="OpenChangelogAsync" disabled="@(string.IsNullOrWhiteSpace(updateStatus.ChangelogUrl))">
+                        View changelog
+                    </button>
+                </div>
+            </div>
+
             <div class="content-card widget-card clock-widget">
                 <div class="widget-header">
                     <svg fill="currentColor" viewBox="0 0 20 20" class="widget-icon">
@@ -426,6 +482,12 @@
 
     private bool _isDisposed = false;
     private bool _hasInitialized = false;
+    private UpdateCheckResult updateStatus = new()
+    {
+        CurrentVersion = UpdateService.GetCurrentVersionValue(),
+        LatestVersion = UpdateService.GetCurrentVersionValue()
+    };
+    private bool isCheckingUpdates = false;
 
     protected override Task OnInitializedAsync()
     {
@@ -486,6 +548,8 @@
             LoadSystemComponentsInfo();
             InvokeAsync(StateHasChanged);
         });
+
+        _ = CheckForUpdatesAsync(showFeedback: false);
 
         await InvokeAsync(StateHasChanged);
     }
@@ -1132,6 +1196,119 @@
         Logger.LogInformation("Clearing all activities");
         ActivityService.ClearActivities();
         StateHasChanged();
+    }
+
+    private bool CanDownloadUpdate =>
+        updateStatus?.IsUpdateAvailable == true &&
+        !string.IsNullOrWhiteSpace(updateStatus.DownloadUrl);
+
+    private string GetUpdateStatusMessage()
+    {
+        if (isCheckingUpdates)
+            return "Checking for updates...";
+
+        if (!string.IsNullOrWhiteSpace(updateStatus.Error))
+            return updateStatus.Error!;
+
+        if (updateStatus.IsUpdateAvailable)
+            return $"Version {updateStatus.DisplayLatestVersion} is available.";
+
+        return "You are on the latest version.";
+    }
+
+    private string GetUpdateStatusClass()
+    {
+        if (isCheckingUpdates)
+            return "checking";
+
+        if (!string.IsNullOrWhiteSpace(updateStatus.Error))
+            return "warning";
+
+        if (updateStatus.IsUpdateAvailable)
+            return "available";
+
+        return "ok";
+    }
+
+    private async Task CheckForUpdatesAsync(bool showFeedback = true)
+    {
+        if (isCheckingUpdates || _isDisposed)
+            return;
+
+        isCheckingUpdates = true;
+        await InvokeAsync(StateHasChanged);
+
+        try
+        {
+            var result = await UpdateService.CheckForUpdatesAsync(HttpClient, Logger);
+            updateStatus = result;
+
+            if (!string.IsNullOrWhiteSpace(result.Error))
+            {
+                if (showFeedback)
+                    NotificationService.ShowWarning(result.Error);
+            }
+            else if (result.IsUpdateAvailable)
+            {
+                NotificationService.ShowInfo($"New version {result.DisplayLatestVersion} is available");
+                ActivityService.AddActivity($"Update available: v{result.DisplayLatestVersion}", "info");
+            }
+            else if (showFeedback)
+            {
+                NotificationService.ShowSuccess("You are up to date");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to check for updates");
+            if (showFeedback)
+                NotificationService.ShowError("Unable to check for updates right now");
+        }
+        finally
+        {
+            isCheckingUpdates = false;
+            if (!_isDisposed)
+                await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private async Task DownloadUpdateAsync()
+    {
+        if (!CanDownloadUpdate)
+        {
+            NotificationService.ShowWarning("No update available to download right now");
+            return;
+        }
+
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("open", updateStatus.DownloadUrl, "_blank");
+            ActivityService.AddActivity($"Downloading update v{updateStatus.DisplayLatestVersion}", "success");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to open update download link");
+            NotificationService.ShowError("Couldn't launch the download link");
+        }
+    }
+
+    private async Task OpenChangelogAsync()
+    {
+        if (string.IsNullOrWhiteSpace(updateStatus.ChangelogUrl))
+        {
+            NotificationService.ShowWarning("No changelog link available");
+            return;
+        }
+
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("open", updateStatus.ChangelogUrl, "_blank");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to open changelog link");
+            NotificationService.ShowError("Couldn't open the changelog link");
+        }
     }
 
     // ARK Path Management Methods

--- a/RazorReaper/Models/UpdateCheckResult.cs
+++ b/RazorReaper/Models/UpdateCheckResult.cs
@@ -1,0 +1,18 @@
+namespace RazorReaper.Models;
+
+public class UpdateCheckResult
+{
+    public Version CurrentVersion { get; set; } = new Version(0, 0, 0, 0);
+    public Version? LatestVersion { get; set; }
+    public string? DownloadUrl { get; set; }
+    public string? ChangelogUrl { get; set; }
+    public bool IsMandatory { get; set; }
+    public DateTime? CheckedAt { get; set; }
+    public string? Error { get; set; }
+
+    public bool IsUpdateAvailable =>
+        LatestVersion != null && LatestVersion > CurrentVersion;
+
+    public string DisplayCurrentVersion => CurrentVersion.ToString();
+    public string DisplayLatestVersion => LatestVersion?.ToString() ?? "Unknown";
+}

--- a/RazorReaper/Services/UpdateService.cs
+++ b/RazorReaper/Services/UpdateService.cs
@@ -1,31 +1,73 @@
+using System.Net.Http;
 using System.Reflection;
-using AutoUpdaterDotNET;
+using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
+using RazorReaper.Models;
 
 namespace RazorReaper.Services
 {
     public static class UpdateService
     {
+        private const string UpdateManifestUrl = "https://raw.githubusercontent.com/CedrickGD/RazorReaper/master/update.xml";
+
         public static string GetCurrentVersion()
         {
-            var version = Assembly.GetExecutingAssembly().GetName().Version;
-            if (version == null)
-            {
-                return "0.0.0";
-            }
-
-            return $"{version.Major}.{version.Minor}.{version.Build}";
+            return GetCurrentVersionValue().ToString();
         }
 
-        public static void CheckForUpdates()
+        public static Version GetCurrentVersionValue()
         {
-            AutoUpdater.ShowSkipButton = true;
-            AutoUpdater.ShowRemindLaterButton = true;
-            AutoUpdater.LetUserSelectRemindLater = true;
-            AutoUpdater.RemindLaterTimeSpan = RemindLaterFormat.Days;
-            AutoUpdater.RemindLaterAt = 1;
-            AutoUpdater.RunUpdateAsAdmin = false;
-            AutoUpdater.ReportErrors = true;
-            AutoUpdater.Start("https://raw.githubusercontent.com/CedrickGD/RazorReaper/master/update.xml");
+            return Assembly.GetExecutingAssembly().GetName().Version ?? new Version(0, 0, 0, 0);
+        }
+
+        public static async Task<UpdateCheckResult> CheckForUpdatesAsync(HttpClient httpClient, ILogger? logger = null, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(httpClient);
+
+            var result = new UpdateCheckResult
+            {
+                CurrentVersion = GetCurrentVersionValue(),
+                CheckedAt = DateTime.Now
+            };
+
+            try
+            {
+                var manifestContent = await httpClient.GetStringAsync(UpdateManifestUrl, cancellationToken);
+                var document = XDocument.Parse(manifestContent);
+                var root = document.Root;
+
+                if (root == null)
+                {
+                    result.Error = "Update manifest is empty.";
+                    return result;
+                }
+
+                var versionString = root.Element("version")?.Value?.Trim();
+                if (Version.TryParse(versionString, out var latestVersion))
+                {
+                    result.LatestVersion = latestVersion;
+                }
+                else
+                {
+                    result.Error = "Couldn't read the latest version number.";
+                    return result;
+                }
+
+                result.DownloadUrl = root.Element("url")?.Value?.Trim();
+                result.ChangelogUrl = root.Element("changelog")?.Value?.Trim();
+                result.IsMandatory = bool.TryParse(root.Element("mandatory")?.Value, out var mandatory) && mandatory;
+                result.CheckedAt = DateTime.Now;
+
+                logger?.LogInformation("Update manifest pulled. Current={Current} Latest={Latest} Mandatory={Mandatory}",
+                    result.CurrentVersion, result.LatestVersion, result.IsMandatory);
+            }
+            catch (Exception ex)
+            {
+                result.Error = "Unable to check for updates right now.";
+                logger?.LogWarning(ex, "Failed to retrieve update manifest from {ManifestUrl}", UpdateManifestUrl);
+            }
+
+            return result;
         }
     }
 }

--- a/RazorReaper/wwwroot/css/home-styles.css
+++ b/RazorReaper/wwwroot/css/home-styles.css
@@ -40,6 +40,192 @@
     margin-bottom: 2rem;
 }
 
+.update-widget {
+    background: linear-gradient(135deg, rgba(75, 0, 130, 0.22), rgba(15, 15, 25, 0.9));
+    border: 1px solid rgba(139, 92, 246, 0.35);
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.55);
+}
+
+.update-header-text h3 {
+    margin: 0;
+    color: var(--text-primary);
+}
+
+.update-header-text p {
+    margin: 2px 0 0;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.version-pill {
+    margin-left: auto;
+    padding: 8px 12px;
+    border-radius: 999px;
+    background: rgba(139, 92, 246, 0.15);
+    color: #c4b5fd;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    border: 1px solid rgba(139, 92, 246, 0.4);
+}
+
+.update-status-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.status-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    border-radius: 12px;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+    color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.status-chip .status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--text-secondary);
+    box-shadow: 0 0 12px rgba(255, 255, 255, 0.4);
+}
+
+.status-chip.ok {
+    border-color: rgba(52, 211, 153, 0.4);
+    color: #a7f3d0;
+}
+
+.status-chip.ok .status-dot {
+    background: #34d399;
+    box-shadow: 0 0 12px rgba(52, 211, 153, 0.6);
+}
+
+.status-chip.available {
+    border-color: rgba(139, 92, 246, 0.6);
+    color: #c4b5fd;
+}
+
+.status-chip.available .status-dot {
+    background: #a78bfa;
+    box-shadow: 0 0 12px rgba(167, 139, 250, 0.8);
+}
+
+.status-chip.warning {
+    border-color: rgba(245, 158, 11, 0.5);
+    color: #fbbf24;
+}
+
+.status-chip.warning .status-dot {
+    background: #f59e0b;
+    box-shadow: 0 0 12px rgba(245, 158, 11, 0.8);
+}
+
+.status-chip.checking {
+    border-color: rgba(59, 130, 246, 0.5);
+    color: #bfdbfe;
+}
+
+.status-chip.checking .status-dot {
+    background: #60a5fa;
+    box-shadow: 0 0 12px rgba(96, 165, 250, 0.7);
+}
+
+.checked-at {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.version-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.85rem;
+    margin-bottom: 1.2rem;
+}
+
+.version-card {
+    padding: 12px 14px;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(0, 0, 0, 0.25);
+}
+
+.version-card.latest {
+    border-color: rgba(139, 92, 246, 0.5);
+    background: linear-gradient(135deg, rgba(139, 92, 246, 0.08), rgba(0, 0, 0, 0.25));
+}
+
+.version-card .label {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.version-card .value {
+    margin: 4px 0 0;
+    color: var(--text-primary);
+    font-weight: 700;
+    font-size: 1.1rem;
+}
+
+.update-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.update-actions .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.update-actions .btn:hover:enabled {
+    background: rgba(139, 92, 246, 0.12);
+    border-color: rgba(139, 92, 246, 0.6);
+    transform: translateY(-1px);
+}
+
+.update-actions .btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.update-actions .btn-primary {
+    background: linear-gradient(135deg, #7c3aed, #5b21b6);
+    border-color: rgba(124, 58, 237, 0.6);
+}
+
+.update-actions .btn-tertiary {
+    border-style: dashed;
+}
+
+.update-actions .loader {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.2);
+    border-top-color: #c084fc;
+    animation: spin 1s linear infinite;
+}
+
+.update-actions .btn-primary:disabled {
+    background: linear-gradient(135deg, rgba(124, 58, 237, 0.6), rgba(91, 33, 182, 0.6));
+}
+
 .widget-card {
     padding: 1.25rem;
     animation: fadeInUp 0.6s ease-out;


### PR DESCRIPTION
## Summary
- replace the system AutoUpdater pop-up with an in-app themed update experience
- add a Home dashboard Update Center card with status, changelog, and download actions
- parse the update manifest into a reusable model for richer version details

## Testing
- dotnet build (fails: dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959465403dc8333bfa66158b8b4763b)